### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "pygame"
+run = ""

--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
 # ygo-fm-pygame
 a yugioh game heavily inspired by the classic PSX game Yu-Gi-Oh! Forbidden Memories. Made using pygame
+[![Run on Repl.it](https://repl.it/badge/github/ZeraTheMant/ygo-fm-pygame)](https://repl.it/github/ZeraTheMant/ygo-fm-pygame)


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@msajid7002/ygo-fm-pygame-1).

Sorry, I'm new to GitHub and found your code and I was hoping to see it work